### PR TITLE
Add Magicstomp patch download button to tabbed GUI

### DIFF
--- a/realtime_magicstomp.py
+++ b/realtime_magicstomp.py
@@ -38,6 +38,7 @@ class RealtimeMagicstomp:
     SYX_HEADER = SYSEX_HEADER
     SYX_FOOTER = SYSEX_FOOTER
     PARAM_SEND_CMD = PARAMETER_SEND_CMD
+    BULK_RESPONSE_HEADER = [0x43, 0x7D, 0x30, 0x55, 0x42, 0x39, 0x39]
 
     # Structure des patches (re-export depuis magicstomp_sysex pour compatibilité)
     PATCH_COMMON_LENGTH = SYSEX_PATCH_COMMON_LENGTH
@@ -313,13 +314,99 @@ class RealtimeMagicstomp:
     def tweak_multiple_parameters(self, parameters: Dict[int, int], immediate: bool = False):
         """
         Modifie plusieurs paramètres en une fois.
-        
+
         Args:
             parameters: Dict {offset: value}
             immediate: Si True, envoie immédiatement
         """
         for offset, value in parameters.items():
             self.tweak_parameter(offset, value, immediate)
+
+    def request_patch(self, patch_index: int = 0, timeout: float = 2.0) -> Optional[Dict[str, Any]]:
+        """Demande au Magicstomp d'envoyer le patch courant."""
+
+        if not self.output_port:
+            self._initialize_midi()
+
+        if not self.output_port:
+            print("❌ Aucun port MIDI de sortie disponible pour la requête de patch")
+            return None
+
+        if self.input_port is None:
+            try:
+                self.input_port = mido.open_input(self.midi_port_name)
+                print(f"✅ Port MIDI d'entrée ouvert: {self.midi_port_name}")
+            except Exception as exc:  # pragma: no cover - dépend du matériel
+                print(f"❌ Erreur ouverture port MIDI d'entrée: {exc}")
+                return None
+
+        if self.input_port:
+            while self.input_port.poll() is not None:
+                pass
+
+        request = [0x43, 0x7D, 0x50, 0x55, 0x42, 0x30, 0x01, patch_index & 0x7F]
+        try:
+            self.output_port.send(mido.Message('sysex', data=request))
+            print(f"📥 Requête de dump envoyée pour le patch {patch_index + 1:02d}")
+        except Exception as exc:  # pragma: no cover - dépend du matériel
+            print(f"❌ Erreur envoi requête de dump: {exc}")
+            return None
+
+        start = time.time()
+        common_data: Optional[List[int]] = None
+        effect_data: Optional[List[int]] = None
+        received_index = patch_index
+
+        while time.time() - start < timeout:
+            msg = self.input_port.poll() if self.input_port else None
+            if msg is None:
+                time.sleep(0.01)
+                continue
+
+            if msg.type != 'sysex':
+                continue
+
+            data = list(msg.data)
+            if len(data) < 10 or data[:7] != self.BULK_RESPONSE_HEADER:
+                continue
+
+            length = data[8]
+            command = data[9]
+
+            if length == 0 and command == 0x30:
+                if len(data) >= 12:
+                    sub_command = data[10]
+                    received_index = data[11]
+                    if sub_command == 0x11 and common_data and effect_data:
+                        break
+                continue
+
+            if command != 0x20 or len(data) < 13:
+                continue
+
+            section = data[10]
+            section_offset = data[11]
+            payload = data[12:12 + length]
+
+            if section == 0x00 and section_offset == 0x00 and length >= self.PATCH_COMMON_LENGTH:
+                common_data = payload[: self.PATCH_COMMON_LENGTH]
+                print(f"📦 Données 'common' reçues ({len(common_data)} octets)")
+            elif section == 0x01 and section_offset == 0x00 and length >= self.PATCH_EFFECT_LENGTH:
+                effect_data = payload[: self.PATCH_EFFECT_LENGTH]
+                print(f"🎛️ Données d'effet reçues ({len(effect_data)} octets)")
+
+            if common_data and effect_data:
+                break
+
+        if not common_data or not effect_data:
+            print("❌ Patch incomplet reçu depuis le Magicstomp")
+            return None
+
+        return {
+            'patch_index': received_index,
+            'common': common_data,
+            'effect': effect_data,
+        }
     
     def _send_message_immediate(self, message: List[int]):
         """Envoie un message immédiatement."""


### PR DESCRIPTION
## Summary
- add a download button in the tabbed compact GUI to fetch the current Magicstomp patch and show it in the effect editor
- teach `BaseEffectWidget` how to decode Magicstomp SysEx values so widgets can render downloaded patches accurately
- extend `RealtimeMagicstomp` with a bulk-dump request helper used by the new GUI button

## Testing
- pytest tests/test_effect_display.py *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3864b279c8329abbe32d5cbc7b3e2